### PR TITLE
Es add entity set

### DIFF
--- a/src/Controller/AbstractEntityController.php
+++ b/src/Controller/AbstractEntityController.php
@@ -60,6 +60,13 @@ class AbstractEntityController {
   }
 
   /**
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   */
+  public function setEntity(EntityInterface $entity) {
+    $this->entity = $entity;
+  }
+
+  /**
    * @return string
    */
   public function getEntityType() {

--- a/src/Factory/EntityControllerFactory.php
+++ b/src/Factory/EntityControllerFactory.php
@@ -7,14 +7,28 @@
 
 namespace Drupal\cw_tool\Factory;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\cw_tool\Controller\AbstractEntityController;
 
+/**
+ * Class EntityControllerFactory
+ * @package Drupal\cw_tool\Factory
+ *
+ * The purpose of this class is to create entity controllers.
+ */
 class EntityControllerFactory {
 
   const MASTER_CONTROLLER_CLASS = 'Drupal\cw_tool\Controller\AbstractEntityController';
 
+  /**
+   * @var string
+   */
   private $entityType;
 
+  /**
+   * @var string
+   */
   private $controllerClass;
 
   /**
@@ -22,6 +36,18 @@ class EntityControllerFactory {
    */
   private $entityManager;
 
+  /**
+   * EntityControllerFactory constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
+   *   Drupal entity manager.
+   * @param string $entityType
+   *   Entity type.
+   * @param string $controllerClass
+   *   Actual entity controller class.
+   *
+   * @throws \InvalidArgumentException
+   */
   public function __construct(EntityManagerInterface $entityManager, $entityType, $controllerClass) {
     $this->entityType = $entityType;
 
@@ -33,8 +59,32 @@ class EntityControllerFactory {
     $this->entityManager = $entityManager;
   }
 
+  /**
+   * Factory method to provide the controller by id.
+   *
+   * @param int|null $id
+   *   ID of the entity.
+   *
+   * @return AbstractEntityController
+   *   Instance of the controller.
+   */
   public function initWithID($id) {
     return new $this->controllerClass($this->entityManager, $this->entityType, $id);
+  }
+
+  /**
+   * Factory method to provide the controller by id.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   *
+   * @return AbstractEntityController
+   *   Instance of the controller.
+   */
+  public function initWithEntity(EntityInterface $entity) {
+    $controller = $this->initWithID($entity->id());
+    $controller->setEntity($entity);
+    return $controller;
   }
 
 }

--- a/tests/src/Unit/Controller/AbstractEntityControllerTest.php
+++ b/tests/src/Unit/Controller/AbstractEntityControllerTest.php
@@ -5,7 +5,7 @@
 
 namespace Drupal\Tests\cw_tool\Unit\Controller;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\UnitTestCase;
 use Drupal\Tests\cw_tool\Fixtures\Controller\MinimalEntityController;
 
 /**
@@ -16,7 +16,7 @@ use Drupal\Tests\cw_tool\Fixtures\Controller\MinimalEntityController;
  *
  * @group cw_tool
  */
-class AbstractEntityControllerTest extends KernelTestBase {
+class AbstractEntityControllerTest extends UnitTestCase {
 
   /**
    * @var \PHPUnit_Framework_MockObject_MockObject
@@ -29,6 +29,7 @@ class AbstractEntityControllerTest extends KernelTestBase {
   private $entityStorageMock;
 
   public function setUp() {
+    include_once __DIR__ . '/../../Fixtures/Controller/MinimalEntityController.php';
     $this->entityManagerMock = $this->getMock('Drupal\Core\Entity\EntityManagerInterface');
     $this->entityStorageMock = $this->getMock('Drupal\Core\Entity\EntityStorageInterface');
     parent::setUp();


### PR DESCRIPTION
This includes the set entity method that is on the v3.1 branch.

The previous test fails on Drupal 8.3 as the php unit autoload logic has changed. I have manually loaded the file - but I am not sure if this is the correct approach.

In drupal_phpunit_get_extension_namespaces function the logic has changed so the autoload will only recognise the following directories `$suite_names = ['Unit', 'Kernel', 'Functional', 'FunctionalJavascript'];`

I can't find examples of how to load in our additional Fixtures directory - however this will for know at least stop the test from failing.